### PR TITLE
AArch64: Eliminate redundant constant load instructions.

### DIFF
--- a/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64SuitesCreator.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64SuitesCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,8 @@ import java.util.ListIterator;
 
 import org.graalvm.compiler.debug.GraalError;
 import org.graalvm.compiler.java.DefaultSuitesCreator;
+import org.graalvm.compiler.lir.aarch64.AArch64RedundantInstructionElimination;
+import org.graalvm.compiler.lir.phases.LIRSuites;
 import org.graalvm.compiler.nodes.graphbuilderconf.GraphBuilderConfiguration.Plugins;
 import org.graalvm.compiler.options.OptionValues;
 import org.graalvm.compiler.phases.BasePhase;
@@ -72,5 +74,12 @@ public class AArch64SuitesCreator extends DefaultSuitesCreator {
             throw GraalError.shouldNotReachHere("Cannot find phase to insert AArch64ReadReplacementPhase");
         }
         return suites;
+    }
+
+    @Override
+    public LIRSuites createLIRSuites(OptionValues options) {
+        LIRSuites lirSuites = super.createLIRSuites(options);
+        lirSuites.getPreAllocationOptimizationStage().prependPhase(new AArch64RedundantInstructionElimination());
+        return lirSuites;
     }
 }

--- a/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64RedundantInstructionElimination.java
+++ b/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64RedundantInstructionElimination.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Arm Limited and affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.compiler.lir.aarch64;
+
+import static org.graalvm.compiler.lir.LIRValueUtil.asVariable;
+import static org.graalvm.compiler.lir.LIRValueUtil.isVariable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+
+import org.graalvm.compiler.core.common.cfg.AbstractBlockBase;
+import org.graalvm.compiler.debug.DebugContext;
+import org.graalvm.compiler.debug.Indent;
+import org.graalvm.compiler.lir.InstructionValueConsumer;
+import org.graalvm.compiler.lir.LIR;
+import org.graalvm.compiler.lir.LIRInstruction;
+import org.graalvm.compiler.lir.VariableMap;
+import org.graalvm.compiler.lir.gen.LIRGenerationResult;
+import org.graalvm.compiler.lir.phases.PreAllocationOptimizationPhase;
+
+import jdk.vm.ci.code.TargetDescription;
+import jdk.vm.ci.meta.Value;
+
+/**
+ * This optimization tries to remove unused instructions. Currently it only removes the constant
+ * load instructions. The unused constant mov may exist after match rules.
+ */
+public final class AArch64RedundantInstructionElimination extends PreAllocationOptimizationPhase {
+
+    @Override
+    protected void run(TargetDescription target, LIRGenerationResult lirGenRes, PreAllocationOptimizationContext context) {
+        new Optimization(lirGenRes.getLIR()).apply();
+    }
+
+    private static final class Optimization {
+        private final LIR lir;
+        private final VariableMap<DefEntry> unUsedDefs;
+        private final DebugContext debug;
+
+        private Optimization(LIR lir) {
+            this.lir = lir;
+            this.debug = lir.getDebug();
+            this.unUsedDefs = new VariableMap<>();
+        }
+
+        @SuppressWarnings("try")
+        private void apply() {
+            try (Indent indent = debug.logAndIndent("AArch64RedundantInstructionElimination")) {
+                try (DebugContext.Scope s = debug.scope("CollectUnusedInstructions")) {
+                    for (AbstractBlockBase<?> b : lir.getControlFlowGraph().getBlocks()) {
+                        collectUnusedInBlock(b);
+                    }
+
+                    if (!unUsedDefs.isEmpty()) {
+                        debug.log("Redundant instructions that will be removed later: %s", unUsedDefs);
+                    }
+                } catch (Throwable e) {
+                    throw debug.handle(e);
+                }
+
+                try (DebugContext.Scope s = debug.scope("DeleteUnusedInstructions")) {
+                    unUsedDefs.forEach(this::deleteInstruction);
+                    // Remove unused instructions for each block.
+                    for (AbstractBlockBase<?> b : lir.getControlFlowGraph().getBlocks()) {
+                        removeUnusedInBlock(b);
+                    }
+                } catch (Throwable e) {
+                    throw debug.handle(e);
+                }
+            }
+        }
+
+        /**
+         * Collect unused instructions for a {@code block}.
+         */
+        private void collectUnusedInBlock(AbstractBlockBase<?> block) {
+            InstructionValueConsumer defConsumer = (instruction, value, mode, flags) -> {
+                if (isVariable(value) && isEligibleOp(instruction)) {
+                    DefEntry def = new DefEntry(block, instruction, value);
+                    unUsedDefs.put(asVariable(value), def);
+                }
+            };
+
+            InstructionValueConsumer useConsumer = (instruction, value, mode, flags) -> {
+                if (isVariable(value)) {
+                    DefEntry def = unUsedDefs.get(asVariable(value));
+                    if (def != null) {
+                        assert def.value.equals(value);
+                        // Remove the instruction that defined this value from the unused map. We
+                        // assume that one instruction can only define a variable.
+                        unUsedDefs.remove(asVariable(value));
+                        assert !unUsedDefs.contains(d -> (d.instruction.equals(def.instruction)));
+                    }
+                }
+            };
+
+            int opId = 0;
+            for (LIRInstruction inst : lir.getLIRforBlock(block)) {
+                inst.setId(opId++);
+                inst.visitEachOutput(defConsumer);
+                inst.visitEachInput(useConsumer);
+                inst.visitEachAlive(useConsumer);
+                inst.visitEachTemp(useConsumer);
+                inst.visitEachState(useConsumer);
+            }
+        }
+
+        /**
+         * Currently we only find the unused constant load instructions that can be safely removed.
+         * If there are any other kinds of eligible instructions, please extend the condition here.
+         */
+        private static boolean isEligibleOp(LIRInstruction inst) {
+            return inst.isLoadConstantOp();
+        }
+
+        /**
+         * Remove unused instructions for a {@code block}.
+         */
+        private void removeUnusedInBlock(AbstractBlockBase<?> block) {
+            boolean hasDead = false;
+            ArrayList<LIRInstruction> instructions = lir.getLIRforBlock(block);
+            for (LIRInstruction instruction : instructions) {
+                if (instruction == null) {
+                    hasDead = true;
+                } else {
+                    instruction.setId(-1);
+                }
+            }
+
+            // delete unused instructions
+            if (hasDead) {
+                instructions.removeAll(Collections.singleton(null));
+            }
+        }
+
+        // Set the instruction that will be deleted to null.
+        private void deleteInstruction(DefEntry def) {
+            AbstractBlockBase<?> block = def.block;
+            LIRInstruction instruction = def.instruction;
+            ArrayList<LIRInstruction> instructions = lir.getLIRforBlock(block);
+            assert instructions.contains(instruction);
+            debug.log("deleting instruction %s from block %s", instruction, block);
+            instructions.set(instruction.id(), null);
+        }
+    }
+
+    /**
+     * Represents an output of an instruction.
+     */
+    private static class DefEntry {
+
+        final AbstractBlockBase<?> block;
+        final LIRInstruction instruction;
+        final Value value;
+
+        DefEntry(AbstractBlockBase<?> block, LIRInstruction instruction, Value value) {
+            this.block = block;
+            this.instruction = instruction;
+            this.value = value;
+            assert instruction != null && block != null && value != null;
+        }
+
+        @Override
+        public String toString() {
+            return instruction.toString() + " in block " + block.toString();
+        }
+    }
+}

--- a/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/VariableMap.java
+++ b/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/VariableMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,24 +22,22 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package org.graalvm.compiler.lir.constopt;
+package org.graalvm.compiler.lir;
 
 import java.util.ArrayList;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
-
-import org.graalvm.compiler.lir.Variable;
 
 /**
  * Maps variables to a generic type.
  *
  * TODO (je) evaluate data structure
  */
-class VariableMap<T> {
+public class VariableMap<T> {
 
     private final ArrayList<T> content;
 
-    VariableMap() {
+    public VariableMap() {
         content = new ArrayList<>();
     }
 
@@ -87,4 +85,46 @@ class VariableMap<T> {
         }
     }
 
+    public boolean contains(Predicate<T> predicate) {
+        for (int i = 0; i < content.size(); i++) {
+            T e = content.get(i);
+            if (e != null && predicate.test(e)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean isEmpty() {
+        if (content.isEmpty()) {
+            return true;
+        }
+
+        for (T e : content) {
+            if (e != null) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        if (content.isEmpty()) {
+            return "";
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (T e : content) {
+            if (e != null) {
+                sb.append(e.toString());
+                sb.append(",");
+            }
+        }
+
+        if (sb.indexOf(",") != -1) {
+            sb.deleteCharAt(sb.lastIndexOf(","));
+        }
+        return sb.toString();
+    }
 }

--- a/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/constopt/ConstantLoadOptimization.java
+++ b/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/constopt/ConstantLoadOptimization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,6 +50,7 @@ import org.graalvm.compiler.lir.LIRInstruction.OperandMode;
 import org.graalvm.compiler.lir.StandardOp.LoadConstantOp;
 import org.graalvm.compiler.lir.ValueConsumer;
 import org.graalvm.compiler.lir.Variable;
+import org.graalvm.compiler.lir.VariableMap;
 import org.graalvm.compiler.lir.constopt.ConstantTree.Flags;
 import org.graalvm.compiler.lir.constopt.ConstantTree.NodeCost;
 import org.graalvm.compiler.lir.gen.LIRGenerationResult;


### PR DESCRIPTION
This patch fixes issue: https://github.com/oracle/graal/issues/2216

Unused constant load won't be deleted after match rules. As a result,
it might generate redundant "mov/orr" instructions if the constants
cannot be inlined to codes.

For example, the original codes:

  lsr    w0, w0, #6
  orr    w1, wzr, #0xfffff
  and    w0, w0, w1

will be optimized to the following pattern by adding match rules:

  orr    w1, wzr, #0xfffff
  ubfx   w0, w0, #6, #20

However, the constant "0xfffff" is not deleted even though it will
never be used. To fix it, this patch inserts a phase applied to
LIRInstructions. It's used to eliminate the unused constant load ops
before code generation. Although it is limited to constant load ops
currently, it can also be extended to remove other kinds of unused
instructions if needed in future.

Change-Id: Ibed66714c12e02f400ab494683dee8826ede01a1